### PR TITLE
Fix exec crashing by supplying dummy empty filename.

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ module.exports = function (source) {
   this.cacheable && this.cacheable();
   init(this);
 
-  var contracts = this.exec(source);
+  var contracts = this.exec(source, '');
   var tasks = [];
   for (var name in contracts) {
     var contract = contracts[name];


### PR DESCRIPTION
_compile will fail at run time if no filename is supplied.
