### PR TITLE
Fix check for window, variable is not available in node context

### DIFF
--- a/lib/web3-helper.js
+++ b/lib/web3-helper.js
@@ -6,7 +6,7 @@
  */
 var Web3 = require('web3');
 var web3;
-if (typeof window.web3 !== 'undefined') {
+if (typeof window !== 'undefined' && typeof window.web3 !== 'undefined') {
  web3 = new Web3(window.web3.currentProvider);
 } else {
  web3 = new Web3(new Web3.providers.HttpProvider('__PROVIDER_URL__'));


### PR DESCRIPTION
Sorry, I had a little bug in #14.

When running the code in Node.js, `window` obviously isn't there, so we should catch that case.
