### PR TITLE
Considering removing constructor params for imported contracts. (Reverting #16)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,57 +55,10 @@ import { MyToken, web3 } from './contract/MyToken.sol';
 
 let currentBlock = web3.eth.blockNumber;
 ```
-### Solidity Contract Dependency Injection
-
-This loader is able to automatically inject address of deployed contract if your contracts depends on it.
-To use dependency injection you will need:
- - Contracts.sol - a central file which you will `require` in your js
- - `inject_` constructor variables
-
-Consider such example:
-```
-//Manager.sol
-contract Manager {
-  //Some state + complex stuff that is accessed by other contracts
-}
-
-//SomeContract.sol
-import 'Manager.sol';
-
-contract SomeContract1 {
-
-  address manager;
-
-  function SomeContract(inject_Manager) {
-    manager = inject_Manager;
-  }
-
-  function doSmth() {
-    Manager(manager).someMethod();
-  }
-}
-
-//Contracts.sol will contain just 'import' statements
-import 'SomeContract1';
-```
-
-In JS code:
-```
-var contracts = require('Contracts.sol');
-var SomeContract1 = contracts.SomeContract;
-var Manager = contracts.Manager;
-var web3 = contracts.web3;
-```
-
-In `Contracts.sol` only root contracts can be specified. Loader automatically builds dependency
-graph based on `import` statements and `inject_` constructor variables.
-Run `webpack -d` to see debug information on the order of deployment.
-
-If your construct must accept other variables they should be placed before because loader just appends injected contract addresses to the end of `constructorParams` config variable.
 
 ## Configuration
 
-Configuration is _not needed_ for most common use cases.
+Configuration is _not needed_ for most common use cases. 
 
 ### Options
 
@@ -131,7 +84,7 @@ Configuration is _not needed_ for most common use cases.
 
 #### Config style
 
-Recommended especially for configuring of contract addresses.
+Recommended especially for configuring of contract addresses. 
 
 ```js
 // webpack.config.js

--- a/index.js
+++ b/index.js
@@ -3,42 +3,43 @@ var async = require('async');
 var fs = require('fs');
 var loaderUtils = require('loader-utils');
 var path = require('path');
-var Graph = require("graphlib").Graph;
-var GraphAlgorithms = require("graphlib/lib/alg");
 
 var config;
 var web3;
 
-module.exports = function (compiledContractsSource) {
+module.exports = function (source) {
   var loaderCallback = this.async();
   this.cacheable && this.cacheable();
   init(this);
 
-  var contractMap = this.exec(compiledContractsSource, '');
-  var compiledContracts = toArray(contractMap);
-  sortByDependencies(compiledContracts);
+  var contracts = this.exec(source, '');
+  var tasks = [];
+  for (var name in contracts) {
+    var contract = contracts[name];
+    tasks.push({
+      name: name,
+      abi: contract.abi,
+      bytecode: contract.bytecode
+    });
+  }
 
   var web3Source = fs.readFileSync(path.join(__dirname, '/lib/web3-helper.js'), 'utf8');
   web3Source = web3Source.replace('__PROVIDER_URL__', config.provider);
   var output = web3Source + '\n';
   output += 'module.exports = {\n';
 
-  async.mapSeries(
-    compiledContracts,
-    function (contract, callback) {
-      deploy(contract, callback, contractMap);
-    },
-    function (err, results) {
-      if (err) {
-        return loaderCallback(err);
-      }
-      var instances = [];
-      for (var result of results) {
-        output += JSON.stringify(result.name) + ': ' + 'web3.eth.contract(' + JSON.stringify(result.abi) + ').at(' + JSON.stringify(result.address) + '),\n';
-      }
-      output += 'web3: web3\n};\n';
-      return loaderCallback(null, output);
-    });
+  async.mapSeries(tasks, deploy, function (err, results) {
+    if (err) {
+      return loaderCallback(err);
+    }
+    var instances = [];
+    for (var result of results) {
+      contracts[result.name]['address'] = result.address;
+      output += JSON.stringify(result.name) + ': ' + 'web3.eth.contract(' + JSON.stringify(contracts[result.name]['abi']) + ').at(' + JSON.stringify(result.address) + '),\n';
+    }
+    output += 'web3: web3\n};\n';
+    return loaderCallback(null, output);
+  });
 };
 
 /**
@@ -88,14 +89,14 @@ function mergeConfig(loaderConfig) {
 /**
  * Deploy contracts, if it is not already deployed
  */
-function deploy(contract, callback, contractMap) {
+function deploy(contract, callback) {
   // Reuse existing contract address
   if (config.deployedContracts.hasOwnProperty(contract.name)) {
-    contract.address = config.deployedContracts[contract.name];
-    return callback(null, contract);
+    return callback(null, {
+      name: contract.name,
+      address: config.deployedContracts[contract.name]
+    });
   }
-
-  linkBytecode(contract, contractMap);
 
   // Deploy a new one
   var params = [];
@@ -115,89 +116,13 @@ function deploy(contract, callback, contractMap) {
       return callback(err);
     }
     if (typeof deployed.address !== 'undefined') {
-      contract.address = deployed.address;
-      return callback(null, contract);
+      return callback(null, {
+        name: contract.name,
+        address: deployed.address
+      });
     }
   });
 
   var web3Contract = web3.eth.contract(contract.abi);
   web3Contract.new.apply(web3Contract, params);
-}
-
-function linkBytecode(contract, allContracts) {
-  var deps = getDependenciesFromBytecode(contract.bytecode);
-  for (var i in deps) {
-    var depName = deps[i];
-    var linkedBytecode = linkDependency(
-      contract.bytecode,
-      depName,
-      allContracts[depName].address);
-    contract.bytecode = linkedBytecode;
-  }
-}
-
-function sortByDependencies(compiledContracts) {
-  var depsGraph = buildDependencyGraph(compiledContracts);
-  var dependsOrdering = GraphAlgorithms.postorder(depsGraph, depsGraph.nodes());
-  console.log('Deployment order: ', dependsOrdering);
-  compiledContracts.sort(function (a, b) {
-    return dependsOrdering.indexOf(a.name) - dependsOrdering.indexOf(b.name);
-  });
-}
-
-function buildDependencyGraph(contracts) {
-  var g = new Graph();
-
-  for (var i = 0; i < contracts.length; i++) {
-    var contract = contracts[i];
-    var contractName = contract.name;
-    if (!g.hasNode(contractName)) {
-      g.setNode(contractName);
-    }
-
-    var deps = getDependenciesFromBytecode(contract.bytecode);
-    for (var j = 0; j < deps.length; j++) {
-      var depName = deps[j];
-      if (!g.hasNode(depName)) {
-        g.setNode(depName);
-      }
-
-      g.setEdge(contractName, depName);
-      if (!GraphAlgorithms.isAcyclic(g)) {
-        throw new Error('Dependency ' + contractName + ' -> ' + depName + ' inroduces cycle');
-      }
-    }
-  }
-  return g;
-}
-
-function getDependenciesFromBytecode(bytecode) {
-  // Library references are embedded in the bytecode of contracts with the format
-  //  "__Lib___________________________________" , where "Lib" is your library name and the whole
-  var regex = /__([^_]*)_*/g;
-  var matches;
-  var dependencies = [];
-  while ( (matches = regex.exec(bytecode)) !== null ) {
-    var libName = matches[1];
-    if (dependencies.indexOf(libName) === -1) {
-      dependencies.push(libName);
-    }
-  }
-  return dependencies;
-}
-
-function linkDependency(binary, dependencyName, dependencyAddress) {
-  var binAddress = dependencyAddress.replace("0x", "");
-  var re = new RegExp("__" + dependencyName + "_*", "g");
-  console.log('Linking library \'' + dependencyName + '\' at ' + dependencyAddress);
-  return binary.replace(re, binAddress);
-}
-
-function toArray(compiledContractsMap) {
-  var contracts = [];
-  for (var name in compiledContractsMap) {
-    var contract = compiledContractsMap[name];
-    contracts.push(contract);
-  }
-  return contracts;
 }

--- a/index.js
+++ b/index.js
@@ -8,7 +8,6 @@ var GraphAlgorithms = require("graphlib/lib/alg");
 
 var config;
 var web3;
-var isDebug;
 
 module.exports = function (compiledContractsSource) {
   var loaderCallback = this.async();
@@ -49,7 +48,6 @@ function init(loader) {
   var loaderConfig = loaderUtils.getLoaderConfig(loader, 'web3Loader');
   web3 = require('./lib/web3')(loaderConfig.provider);
   config = mergeConfig(loaderConfig);
-  isDebug = loader.debug;
 }
 
 /**
@@ -100,8 +98,10 @@ function deploy(contract, callback, contractMap) {
   linkBytecode(contract, contractMap);
 
   // Deploy a new one
-  var params = resolveConstructorParams(contract, contractMap);
-  logDebug('Constructor params ' + contract.name + ':', params);
+  var params = [];
+  if (config.constructorParams.hasOwnProperty(contract.name)) {
+    params = config.constructorParams[contract.name];
+  }
   if(contract.bytecode && !contract.bytecode.startsWith('0x')) {
     contract.bytecode = '0x' + contract.bytecode;
   }
@@ -124,20 +124,6 @@ function deploy(contract, callback, contractMap) {
   web3Contract.new.apply(web3Contract, params);
 }
 
-function resolveConstructorParams(contract, contractMap) {
-  var params = (config.constructorParams[contract.name] || []).slice();
-  var injectableDependencies = getDependenciesFromConstructor(contract.abi);
-  injectableDependencies.forEach(function (dep) {
-    var address = contractMap[dep].address;
-    if (address) {
-      params.push(address);
-    } else {
-      throw Error('Contract ' + dep + ' was not deployed because its address is undefined');
-    }
-  });
-  return params;
-}
-
 function linkBytecode(contract, allContracts) {
   var deps = getDependenciesFromBytecode(contract.bytecode);
   for (var i in deps) {
@@ -153,7 +139,7 @@ function linkBytecode(contract, allContracts) {
 function sortByDependencies(compiledContracts) {
   var depsGraph = buildDependencyGraph(compiledContracts);
   var dependsOrdering = GraphAlgorithms.postorder(depsGraph, depsGraph.nodes());
-  logDebug('Deployment order: ', dependsOrdering);
+  console.log('Deployment order: ', dependsOrdering);
   compiledContracts.sort(function (a, b) {
     return dependsOrdering.indexOf(a.name) - dependsOrdering.indexOf(b.name);
   });
@@ -169,7 +155,7 @@ function buildDependencyGraph(contracts) {
       g.setNode(contractName);
     }
 
-    var deps = getDependencies(contract);
+    var deps = getDependenciesFromBytecode(contract.bytecode);
     for (var j = 0; j < deps.length; j++) {
       var depName = deps[j];
       if (!g.hasNode(depName)) {
@@ -183,30 +169,6 @@ function buildDependencyGraph(contracts) {
     }
   }
   return g;
-}
-
-function getDependencies(contract) {
-  return getDependenciesFromBytecode(contract.bytecode)
-    .concat(getDependenciesFromConstructor(contract.abi));
-}
-
-function getDependenciesFromConstructor(abi) {
-  var PREFIX = "inject_";
-  var onlyUnique = function(value, index, self) {
-    return self.indexOf(value) === index;
-  };
-  var firstConstructorInputs = abi
-    .filter(function (item) { return item.type === "constructor"; })
-    //take only first constructor for injection
-    .filter(function (item, index) { return index === 0; })
-    .map(function (item) { return item.inputs; })[0] || [];
-  var dependencies = firstConstructorInputs
-    .filter(function (input) {
-      return input.name.startsWith(PREFIX) && input.type === "address";
-    })
-    .map(function (input) { return input.name.substring(PREFIX.length); })
-    .filter(onlyUnique);
-  return dependencies;
 }
 
 function getDependenciesFromBytecode(bytecode) {
@@ -227,7 +189,7 @@ function getDependenciesFromBytecode(bytecode) {
 function linkDependency(binary, dependencyName, dependencyAddress) {
   var binAddress = dependencyAddress.replace("0x", "");
   var re = new RegExp("__" + dependencyName + "_*", "g");
-  logDebug('Linking library \'' + dependencyName + '\' at ' + dependencyAddress);
+  console.log('Linking library \'' + dependencyName + '\' at ' + dependencyAddress);
   return binary.replace(re, binAddress);
 }
 
@@ -238,10 +200,4 @@ function toArray(compiledContractsMap) {
     contracts.push(contract);
   }
   return contracts;
-}
-
-function logDebug() {
-  if (isDebug) {
-    Function.prototype.apply.call(console.log, console, arguments);
-  }
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
   ],
   "dependencies": {
     "async": "^2.0.0-rc.3",
-    "graphlib": "^2.1.0",
     "loader-utils": "0.2.x"
   },
   "peerDependencies": {


### PR DESCRIPTION
## Why
1. It is not a natural or common use-case to be importing contracts that require constructor params. _Or am I mistaken?_
2. The implementation is overly complicated, requiring building of graphs for a feature that is either very hardly used, or is an anti-pattern of `import` use.
